### PR TITLE
Fix typo in GPU specification for LHM - 1B - HF model

### DIFF
--- a/modelcard.md
+++ b/modelcard.md
@@ -26,7 +26,7 @@
     | LHM-500M |  5 |    1024    |    16 |      40K |    512     | dinov2_vits14_reg & Sapiens-1B | 1024 | 18G GPU, 24G VRAM |
     | LHM-500M-HF  | 5 |    1024    |    16      |      40K       |    512 | dinov2_vitb14_reg & Sapiens-1B |      1024 | 18G GPU, 24G VRAM |
     | LHM-1B |   15 |   1024    |     16      |      40K |    1024 | dinov2_vitb14_reg & Sapiens-1B | 1024 | 22G GPU, 24G VRAM |
-    | LHM-1B-HF |   15|   1024    |     16      |   40K |    1024 | dinov2_vitb14_reg & Sapiens-1B | 1024 | 222G GPU, 24G VRAM |
+    | LHM-1B-HF |   15|   1024    |     16      |   40K |    1024 | dinov2_vitb14_reg & Sapiens-1B | 1024 | 22G GPU, 24G VRAM |
 
 - Model architecture (with motion & save_memory; maximum supported length for 720P video is 20s)
 


### PR DESCRIPTION
Hello! I noticed a potential typo in the model architecture table. For the LHM - 1B - HF entry, the GPU requirement is listed as 222G GPU, which seems inconsistent with other entries (e.g., 16G GPU, 18G GPU, 22G GPU) and typical GPU specifications. I’ve corrected it to 22G GPU to maintain consistency and logical accuracy. Please let me know if this adjustment is appropriate. Thanks!